### PR TITLE
feat: Docker Compose + runbook (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,109 @@
-OPENDOVE_OPENAI_API_KEY=
-OPENDOVE_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/opendove
+# OpenDove environment configuration
+# Copy this file to .env and fill in the values that apply to your setup.
+# All variables use the OPENDOVE_ prefix.
+# The docker-compose.yml sets OPENDOVE_DATABASE_URL automatically — leave it
+# blank here unless you are running the app outside of Docker.
+
+# ── Core ─────────────────────────────────────────────────────────────────────
+
+# Runtime environment. Set to "production" in deployed environments.
 OPENDOVE_ENV=local
+
+# Directory where OpenDove clones repos and creates git worktrees.
+# Default: ~/.opendove  (overridden to a Docker volume in compose)
+# OPENDOVE_WORKSPACE_DIR=~/.opendove
+
+# PostgreSQL connection string (psycopg v3 driver).
+# Leave blank when using docker-compose — the compose file sets this automatically.
+# OPENDOVE_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/opendove
+
+# ── LLM — global defaults ────────────────────────────────────────────────────
+
+# Default LLM provider for all agents. Options: anthropic | openai | gemini
+OPENDOVE_LLM_PROVIDER=anthropic
+
+# Default model for all agents.
+OPENDOVE_LLM_MODEL=claude-sonnet-4-6
+
+# ── LLM — API keys ───────────────────────────────────────────────────────────
+
+# At least one key is required depending on your chosen provider(s).
+OPENDOVE_ANTHROPIC_API_KEY=
+OPENDOVE_OPENAI_API_KEY=
+OPENDOVE_GEMINI_API_KEY=
+
+# ── LLM — per-role overrides (optional) ─────────────────────────────────────
+# Leave blank to inherit the global default above.
+# Options per field: provider = anthropic | openai | gemini
+
+OPENDOVE_PRODUCT_MANAGER_LLM_PROVIDER=
+OPENDOVE_PRODUCT_MANAGER_LLM_MODEL=
+
+OPENDOVE_PROJECT_MANAGER_LLM_PROVIDER=
+OPENDOVE_PROJECT_MANAGER_LLM_MODEL=
+
+OPENDOVE_ARCHITECT_LLM_PROVIDER=
+OPENDOVE_ARCHITECT_LLM_MODEL=
+
+OPENDOVE_DEVELOPER_LLM_PROVIDER=
+OPENDOVE_DEVELOPER_LLM_MODEL=
+
+OPENDOVE_AVA_LLM_PROVIDER=
+OPENDOVE_AVA_LLM_MODEL=
+
+# ── MCP tool servers ─────────────────────────────────────────────────────────
+
+# Command used to launch the Claude Code MCP server.
+# Default: claude  (requires Claude Code CLI installed)
+OPENDOVE_CLAUDE_CODE_MCP_COMMAND=claude
+
+# Command used to launch the CodeX MCP server.
+# Default: codex  (requires CodeX CLI installed)
+OPENDOVE_CODEX_MCP_COMMAND=codex
+
+# Brave Search API key — required for web search tools (PdM, PjM, Architect).
+# Leave blank to disable web search.
+OPENDOVE_BRAVE_SEARCH_API_KEY=
+
+# Command used to launch the Fetch MCP server.
+# Default: npx  (uses npx @modelcontextprotocol/server-fetch)
+OPENDOVE_FETCH_MCP_COMMAND=npx
+
+# ── Per-role tool groups (optional) ─────────────────────────────────────────
+# Comma-separated list of tool groups to enable per role.
+# Available groups: claude_code, codex, web_search, web_fetch
+# Leave blank to use the built-in defaults shown below.
+
+# OPENDOVE_PRODUCT_MANAGER_TOOLS=claude_code,web_search,web_fetch
+# OPENDOVE_PROJECT_MANAGER_TOOLS=claude_code,web_search,web_fetch
+# OPENDOVE_ARCHITECT_TOOLS=claude_code,codex,web_search,web_fetch
+# OPENDOVE_DEVELOPER_TOOLS=claude_code,codex,web_fetch
+# OPENDOVE_AVA_TOOLS=claude_code,web_fetch
+
+# ── GitHub integration ───────────────────────────────────────────────────────
+
+# Personal access token with repo + issues scope.
+# Required for: issue syncing, sub-issue creation, PR management, auto-merge.
+OPENDOVE_GITHUB_TOKEN=
+
+# Label that marks GitHub issues for OpenDove to pick up.
+# Default: opendove
+OPENDOVE_GITHUB_ISSUE_LABEL=opendove
+
+# How often to poll GitHub for new issues (minutes).
+# Default: 5
+OPENDOVE_GITHUB_SYNC_INTERVAL_MINUTES=5
+
+# ── Notifications ────────────────────────────────────────────────────────────
+
+# Email address to send escalation and human-review notifications to.
+# Leave blank to disable email notifications.
+OPENDOVE_NOTIFY_EMAIL_TO=
+
+# Sender address used in outgoing emails.
+OPENDOVE_NOTIFY_EMAIL_FROM=opendove@localhost
+
+# SMTP server configuration. Leave SMTP_HOST blank to disable email.
+OPENDOVE_SMTP_HOST=
+OPENDOVE_SMTP_PORT=587
+OPENDOVE_SMTP_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+# ── Stage 1: dependency resolution ──────────────────────────────────────────
+FROM python:3.12-slim AS deps
+
+WORKDIR /app
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy dependency manifests only — maximises layer cache reuse
+COPY pyproject.toml uv.lock* ./
+
+# Install all runtime deps (no dev extras) into the venv
+RUN uv sync --no-dev --frozen
+
+# ── Stage 2: application image ───────────────────────────────────────────────
+FROM python:3.12-slim AS app
+
+WORKDIR /app
+
+# uv binary needed at runtime for `uv run` invocations (e.g. migrations)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy venv built in stage 1
+COPY --from=deps /app/.venv /app/.venv
+
+# Copy source
+COPY src/ ./src/
+COPY migrations/ ./migrations/
+COPY pyproject.toml uv.lock* alembic.ini* ./
+
+# Activate the venv for all subsequent RUN / CMD invocations
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8000
+
+CMD ["python", "-m", "opendove.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: opendove
+      POSTGRES_PASSWORD: opendove
+      POSTGRES_DB: opendove
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U opendove -d opendove"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build:
+      context: .
+      target: app
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      # Override db URL to use the compose service name
+      OPENDOVE_DATABASE_URL: postgresql+psycopg://opendove:opendove@db:5432/opendove
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    # Run migrations then start the server
+    command: >
+      sh -c "
+        alembic upgrade head &&
+        python -m opendove.main
+      "
+    volumes:
+      # Persist the workspace (git clones, worktrees) across restarts
+      - opendove_workspace:/root/.opendove
+
+volumes:
+  postgres_data:
+  opendove_workspace:

--- a/docs/architecture/tech_strategy.md
+++ b/docs/architecture/tech_strategy.md
@@ -322,3 +322,4 @@ Developer ──→ Architect review ──→ PR creation ──→ AVA
 | Phase 9: AVA CI gate + auto-merge | ✅ Done | 72/72 tests; PR #21; Closes #15 |
 | Phase 10: PjM priority queue | ✅ Done | 64/64 tests; PR #22; Closes #16 |
 | Phase 11: Agent LLM calls + prompts | ✅ Done | 92/92 tests; PR #24; Closes #23 |
+| Phase 12: Docker Compose + runbook | ✅ Done | PR #26; Closes #25 |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,244 @@
+# OpenDove Runbook
+
+End-to-end guide for running OpenDove locally using Docker Compose.
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Install |
+|---|---|---|
+| Docker | 24.x | https://docs.docker.com/get-docker/ |
+| Docker Compose | v2 (bundled with Docker Desktop) | — |
+| Git | any | — |
+| An LLM API key | — | Anthropic / OpenAI / Gemini |
+
+---
+
+## 1. Clone and configure
+
+```bash
+git clone https://github.com/deyiwang27/OpenDove.git
+cd OpenDove
+
+cp .env.example .env
+```
+
+Open `.env` and set at minimum:
+
+```env
+OPENDOVE_ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI / GEMINI key
+OPENDOVE_GITHUB_TOKEN=ghp_...           # required for repo + issue management
+```
+
+Everything else has a sensible default. See `.env.example` for the full reference.
+
+---
+
+## 2. Start the system
+
+```bash
+docker compose up --build
+```
+
+On first run this will:
+1. Build the app image (≈ 2 min)
+2. Start PostgreSQL and wait for it to be healthy
+3. Run Alembic migrations (`alembic upgrade head`)
+4. Start the FastAPI server on port 8000
+
+You should see:
+
+```
+app-1  | INFO:     Application startup complete.
+app-1  | INFO:     Uvicorn running on http://0.0.0.0:8000
+```
+
+Verify it's healthy:
+
+```bash
+curl http://localhost:8000/health
+# {"status":"ok"}
+```
+
+---
+
+## 3. Register a project
+
+OpenDove works against a GitHub repository. Register one with:
+
+```bash
+curl -X POST http://localhost:8000/projects \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-project",
+    "repo_url": "https://github.com/your-org/your-repo.git",
+    "default_branch": "main"
+  }'
+```
+
+Response:
+
+```json
+{
+  "id": "3f2e1a...",
+  "name": "my-project",
+  "status": "idle",
+  "active_task_id": null,
+  "queued_task_count": 0
+}
+```
+
+Save the `id` — you'll need it to submit tasks.
+
+---
+
+## 4. Submit a task
+
+```bash
+PROJECT_ID="3f2e1a..."   # from step 3
+
+curl -X POST http://localhost:8000/projects/$PROJECT_ID/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Add a health endpoint",
+    "intent": "Add GET /health that returns {\"status\": \"ok\"} with HTTP 200.",
+    "success_criteria": [
+      "GET /health returns HTTP 200",
+      "Response body is {\"status\": \"ok\"}",
+      "Unit test for the endpoint passes"
+    ],
+    "owner": "developer",
+    "max_retries": 3,
+    "risk_level": "low"
+  }'
+```
+
+The task is accepted immediately (HTTP 202) and the agent pipeline starts in the background.
+
+---
+
+## 5. Observe progress
+
+**Task status:**
+
+```bash
+TASK_ID="..."   # from the submit response
+
+curl http://localhost:8000/tasks/$TASK_ID
+```
+
+Status values: `pending` → `in_progress` → `awaiting_validation` → `approved` | `rejected` | `escalated`
+
+**App logs (live):**
+
+```bash
+docker compose logs -f app
+```
+
+**Database (optional):**
+
+```bash
+docker compose exec db psql -U opendove -d opendove
+\dt          -- list tables
+SELECT id, title, status FROM tasks ORDER BY created_at DESC LIMIT 10;
+```
+
+---
+
+## 6. Trigger a manual GitHub issue sync
+
+If you have `OPENDOVE_GITHUB_TOKEN` set and issues labelled `opendove` in your repo:
+
+```bash
+curl -X POST http://localhost:8000/projects/$PROJECT_ID/sync
+```
+
+This pulls open issues and creates tasks for any that haven't been synced yet.
+
+---
+
+## 7. Stop and clean up
+
+```bash
+# Stop containers, keep volumes (data survives restart)
+docker compose down
+
+# Stop and delete all data
+docker compose down -v
+```
+
+---
+
+## Troubleshooting
+
+### App exits immediately on startup
+
+Check logs for migration errors:
+
+```bash
+docker compose logs app
+```
+
+Common cause: database not yet ready. The healthcheck retries 10 times with 5s intervals — if PostgreSQL is slow to initialise on your machine, increase `retries` in `docker-compose.yml`.
+
+### `alembic upgrade head` fails with "relation already exists"
+
+Your database has a partial schema from a previous run. Easiest fix:
+
+```bash
+docker compose down -v   # wipes the postgres volume
+docker compose up
+```
+
+### LLM calls fail with authentication errors
+
+Verify your API key is set in `.env`:
+
+```bash
+grep OPENDOVE_ANTHROPIC_API_KEY .env
+```
+
+Make sure there are no trailing spaces and the key is not quoted.
+
+### Tasks stay in `pending` forever
+
+The scheduler runs on a timer. Check that the app started cleanly:
+
+```bash
+curl http://localhost:8000/health
+docker compose logs app | grep "scheduler"
+```
+
+If the scheduler failed to start, restart the app: `docker compose restart app`.
+
+### Port 8000 already in use
+
+Change the host port in `docker-compose.yml`:
+
+```yaml
+ports:
+  - "8080:8000"   # use 8080 instead
+```
+
+---
+
+## Running without Docker (local development)
+
+```bash
+# Install dependencies
+uv sync --extra dev
+
+# Start PostgreSQL (any method — Docker, Homebrew, etc.)
+# then set the connection string:
+export OPENDOVE_DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5432/opendove"
+
+# Run migrations
+uv run alembic upgrade head
+
+# Start the server
+uv run python -m opendove.main
+
+# Run tests
+uv run python -m pytest tests/unit/
+```


### PR DESCRIPTION
## Summary
- `Dockerfile` — two-stage build (deps layer + app layer) using uv; activates venv via PATH
- `docker-compose.yml` — `app` + `db` (PostgreSQL 16); app waits for db healthcheck, runs `alembic upgrade head` before starting
- `.env.example` — full reference for all `OPENDOVE_*` settings with descriptions and defaults
- `docs/runbook.md` — step-by-step guide: prerequisites → configure → start → register project → submit task → observe → troubleshoot

## How to run

```bash
cp .env.example .env
# fill in OPENDOVE_ANTHROPIC_API_KEY and OPENDOVE_GITHUB_TOKEN
docker compose up --build
curl http://localhost:8000/health   # {"status":"ok"}
```

## Test plan
- [x] 92/92 unit tests still pass
- [x] `Dockerfile` builds cleanly (`docker build .`)
- [x] `docker compose up` starts both services and app reaches healthy state
- [x] `GET /health` returns 200 after startup
- [x] `.env.example` covers every setting in `src/opendove/config.py`

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)