### PR TITLE
feat: LLM retry + rate-limit handling with graph escalation

### DIFF
--- a/src/opendove/agents/base.py
+++ b/src/opendove/agents/base.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import logging
+import random
+import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, TypeVar
 
 from langchain_core.language_models import BaseChatModel
@@ -8,7 +12,51 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar("T", bound=BaseModel)
+
+# Transient errors that warrant a retry
+_RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = ()
+
+try:
+    from anthropic import APIConnectionError as AnthropicConnectionError
+    from anthropic import APITimeoutError as AnthropicTimeoutError
+    from anthropic import RateLimitError as AnthropicRateLimitError
+
+    _RETRYABLE_EXCEPTIONS += (
+        AnthropicRateLimitError,
+        AnthropicTimeoutError,
+        AnthropicConnectionError,
+    )
+except ImportError:
+    pass
+
+try:
+    from openai import APIConnectionError as OpenAIConnectionError
+    from openai import APITimeoutError as OpenAITimeoutError
+    from openai import RateLimitError as OpenAIRateLimitError
+
+    _RETRYABLE_EXCEPTIONS += (
+        OpenAIRateLimitError,
+        OpenAITimeoutError,
+        OpenAIConnectionError,
+    )
+except ImportError:
+    pass
+
+
+class LLMCallError(RuntimeError):
+    """Raised when an LLM call fails after all retry attempts are exhausted."""
+
+
+_MAX_RETRIES = 3
+_BASE_DELAY = 1.0  # seconds
+
+
+def _backoff(attempt: int) -> float:
+    """Exponential backoff with full jitter: sleep in [0, base * 2^attempt]."""
+    return random.uniform(0, _BASE_DELAY * (2**attempt))  # noqa: S311
 
 
 class BaseAgent(ABC):
@@ -28,25 +76,59 @@ class BaseAgent(ABC):
 
             self._react_agent = create_react_agent(self.llm, self.tools)
 
+    def _call_with_retry(self, fn: Callable[[], T], label: str = "LLM call") -> T:
+        """Execute *fn* with exponential-backoff retry on transient LLM errors.
+
+        Retries up to _MAX_RETRIES times on known transient exceptions.
+        Raises LLMCallError if all attempts are exhausted.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_RETRIES):
+            try:
+                return fn()
+            except _RETRYABLE_EXCEPTIONS as exc:  # type: ignore[misc]
+                last_exc = exc
+                delay = _backoff(attempt)
+                logger.warning(
+                    "%s failed (attempt %d/%d), retrying in %.1fs: %s",
+                    label,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                    delay,
+                    exc,
+                )
+                time.sleep(delay)
+            except Exception:
+                raise
+        raise LLMCallError(
+            f"{label} failed after {_MAX_RETRIES} attempts"
+        ) from last_exc
+
     def _call_llm(self, user_message: str) -> str:
         """Call the LLM, using a ReAct agent when tools are configured."""
         if self._react_agent is not None:
-            result = self._react_agent.invoke(
-                {
-                    "messages": [
-                        SystemMessage(content=self.system_prompt),
-                        HumanMessage(content=user_message),
-                    ]
-                }
-            )
-            return str(result["messages"][-1].content)
+            def _invoke() -> str:
+                result = self._react_agent.invoke(
+                    {
+                        "messages": [
+                            SystemMessage(content=self.system_prompt),
+                            HumanMessage(content=user_message),
+                        ]
+                    }
+                )
+                return str(result["messages"][-1].content)
 
-        messages = [
-            SystemMessage(content=self.system_prompt),
-            HumanMessage(content=user_message),
-        ]
-        response = self.llm.invoke(messages)
-        return str(response.content)
+            return self._call_with_retry(_invoke, label="ReAct LLM call")
+
+        def _invoke_plain() -> str:
+            messages = [
+                SystemMessage(content=self.system_prompt),
+                HumanMessage(content=user_message),
+            ]
+            response = self.llm.invoke(messages)
+            return str(response.content)
+
+        return self._call_with_retry(_invoke_plain, label="LLM call")
 
     def _call_llm_structured(self, user_message: str, schema: type[T]) -> T:
         """Call the LLM and return a validated Pydantic object.
@@ -54,27 +136,35 @@ class BaseAgent(ABC):
         Uses `llm.with_structured_output` when no tools are configured,
         falling back to a two-step call for ReAct agents.
         Raises `ValueError` if the response cannot be validated.
+        Raises `LLMCallError` if retries are exhausted on a transient error.
         """
         if self._react_agent is not None:
-            # ReAct path: get plain text, then ask the base LLM to structure it.
             raw = self._call_llm(user_message)
             structured_llm = self.llm.with_structured_output(schema)
-            return structured_llm.invoke(  # type: ignore[return-value]
-                [
-                    SystemMessage(content="Convert the following text into the required JSON structure."),
-                    HumanMessage(content=raw),
-                ]
-            )
+
+            def _structure() -> T:
+                return structured_llm.invoke(  # type: ignore[return-value]
+                    [
+                        SystemMessage(content="Convert the following text into the required JSON structure."),
+                        HumanMessage(content=raw),
+                    ]
+                )
+
+            return self._call_with_retry(_structure, label="structured LLM call")
 
         structured_llm = self.llm.with_structured_output(schema)
         messages = [
             SystemMessage(content=self.system_prompt),
             HumanMessage(content=user_message),
         ]
-        result = structured_llm.invoke(messages)
-        if not isinstance(result, schema):
-            raise ValueError(f"LLM returned unexpected type: {type(result)}")
-        return result  # type: ignore[return-value]
+
+        def _invoke_structured() -> T:
+            result = structured_llm.invoke(messages)
+            if not isinstance(result, schema):
+                raise ValueError(f"LLM returned unexpected type: {type(result)}")
+            return result  # type: ignore[return-value]
+
+        return self._call_with_retry(_invoke_structured, label="structured LLM call")
 
     @abstractmethod
     def run(self, state: Any) -> Any:

--- a/src/opendove/orchestration/graph.py
+++ b/src/opendove/orchestration/graph.py
@@ -5,9 +5,11 @@ from typing import Any, Literal, NotRequired, TypedDict
 
 from langgraph.graph import END, START, StateGraph
 
-from opendove.agents.base import BaseAgent
+from opendove.agents.base import BaseAgent, LLMCallError
 from opendove.models.task import Role, Task, TaskStatus
 from opendove.validation.contracts import ValidationDecision, ValidationResult
+
+_log = __import__("logging").getLogger(__name__)
 
 
 class GraphState(TypedDict):
@@ -147,6 +149,36 @@ def _route_after_ava(state: GraphState) -> Literal["approve", "architect_review"
     return "escalate"
 
 
+def _wrap_with_llm_error_guard(node_fn: GraphNode, node_name: str) -> GraphNode:
+    """Wrap a graph node so that LLMCallError escalates the task instead of crashing."""
+
+    def guarded(state: GraphState) -> GraphState:
+        try:
+            return node_fn(state)
+        except LLMCallError as exc:
+            _log.error("LLM call failed in %s, escalating task: %s", node_name, exc)
+            task = state["task"].model_copy(
+                update={
+                    "status": TaskStatus.ESCALATED,
+                    "validation_result": ValidationResult(
+                        task_id=state["task"].id,
+                        decision=ValidationDecision.ESCALATE,
+                        rationale=f"LLM call failed in {node_name}: {exc}",
+                    ),
+                }
+            )
+            return {
+                **state,
+                "task": task,
+                "messages": [
+                    *state["messages"],
+                    f"{node_name}: escalated due to LLM failure.",
+                ],
+            }
+
+    return guarded
+
+
 def build_orchestration_summary() -> str:
     ordered_roles = [
         Role.PRODUCT_MANAGER,
@@ -170,37 +202,54 @@ def build_graph(
 ) -> Any:
     graph_builder = StateGraph(GraphState)
     effective_developer_node = developer_node_fn or developer_node
-    effective_product_manager_node = (
-        product_manager_agent.run if product_manager_agent is not None else product_manager_node
-    )
-    effective_project_manager_node = (
-        project_manager_agent.run if project_manager_agent is not None else project_manager_node
-    )
-    effective_lead_architect_node = (
-        lead_architect_agent.run if lead_architect_agent is not None else lead_architect_node
-    )
-    effective_architect_review_node = (
-        architect_review_agent.run
-        if architect_review_agent is not None
-        else architect_review_node
-    )
-    effective_developer_node = (
-        developer_agent.run if developer_agent is not None else effective_developer_node
-    )
-    effective_ava_node = ava_agent.run if ava_agent is not None else ava_node
 
-    graph_builder.add_node("product_manager_node", effective_product_manager_node)
-    graph_builder.add_node("project_manager_node", effective_project_manager_node)
-    graph_builder.add_node("lead_architect_node", effective_lead_architect_node)
-    graph_builder.add_node("architect_review_node", effective_architect_review_node)
-    graph_builder.add_node("developer_node", effective_developer_node)
-    graph_builder.add_node("ava_node", effective_ava_node)
+    raw_nodes: dict[str, GraphNode] = {
+        "product_manager_node": (
+            product_manager_agent.run if product_manager_agent is not None else product_manager_node
+        ),
+        "project_manager_node": (
+            project_manager_agent.run if project_manager_agent is not None else project_manager_node
+        ),
+        "lead_architect_node": (
+            lead_architect_agent.run if lead_architect_agent is not None else lead_architect_node
+        ),
+        "architect_review_node": (
+            architect_review_agent.run
+            if architect_review_agent is not None
+            else architect_review_node
+        ),
+        "developer_node": (
+            developer_agent.run if developer_agent is not None else effective_developer_node
+        ),
+        "ava_node": ava_agent.run if ava_agent is not None else ava_node,
+    }
+
+    for name, fn in raw_nodes.items():
+        graph_builder.add_node(name, _wrap_with_llm_error_guard(fn, name))
+
+    def _route_after_pipeline_node(
+        next_node: str,
+    ) -> Callable[[GraphState], Literal["escalate"] | str]:
+        def _router(state: GraphState) -> Literal["escalate"] | str:
+            if state["task"].status is TaskStatus.ESCALATED:
+                return "escalate"
+            return next_node
+
+        return _router
 
     graph_builder.add_edge(START, "product_manager_node")
-    graph_builder.add_edge("product_manager_node", "project_manager_node")
-    graph_builder.add_edge("project_manager_node", "lead_architect_node")
-    graph_builder.add_edge("lead_architect_node", "developer_node")
-    graph_builder.add_edge("developer_node", "ava_node")
+    for src, dst in [
+        ("product_manager_node", "project_manager_node"),
+        ("project_manager_node", "lead_architect_node"),
+        ("lead_architect_node", "developer_node"),
+        ("developer_node", "ava_node"),
+    ]:
+        graph_builder.add_conditional_edges(
+            src,
+            _route_after_pipeline_node(dst),
+            {"escalate": END, dst: dst},
+        )
+
     graph_builder.add_conditional_edges(
         "ava_node",
         _route_after_ava,
@@ -210,6 +259,10 @@ def build_graph(
             "escalate": END,
         },
     )
-    graph_builder.add_edge("architect_review_node", "ava_node")
+    graph_builder.add_conditional_edges(
+        "architect_review_node",
+        _route_after_pipeline_node("ava_node"),
+        {"escalate": END, "ava_node": "ava_node"},
+    )
 
     return graph_builder.compile()

--- a/tests/unit/test_llm_retry.py
+++ b/tests/unit/test_llm_retry.py
@@ -1,0 +1,185 @@
+"""Unit tests for LLM retry logic in BaseAgent."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opendove.agents.base import BaseAgent, LLMCallError, _MAX_RETRIES
+from opendove.orchestration.graph import GraphState, build_graph
+from opendove.models.task import Role, Task, TaskStatus
+from opendove.validation.contracts import ValidationDecision
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete agent for testing
+# ---------------------------------------------------------------------------
+
+
+class ConcreteAgent(BaseAgent):
+    def __init__(self, llm: Any) -> None:
+        self.llm = llm
+        self.system_prompt = "You are a test agent."
+        self.tools = []
+        self._react_agent = None
+
+    def run(self, state: GraphState) -> GraphState:
+        return state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_retryable_error() -> Exception:
+    """Return an Anthropic RateLimitError if available, else a plain RuntimeError subclass."""
+    try:
+        from anthropic import RateLimitError
+        response = MagicMock()
+        response.status_code = 429
+        return RateLimitError("rate limited", response=response, body={})
+    except (ImportError, TypeError):
+        pass
+    try:
+        from anthropic import APIConnectionError
+        return APIConnectionError(request=MagicMock())
+    except (ImportError, TypeError):
+        pass
+    # Fallback: patch _RETRYABLE_EXCEPTIONS directly in the test
+    return RuntimeError("synthetic transient error")
+
+
+# ---------------------------------------------------------------------------
+# _call_with_retry tests
+# ---------------------------------------------------------------------------
+
+
+def test_call_with_retry_succeeds_on_first_attempt() -> None:
+    llm = MagicMock()
+    agent = ConcreteAgent(llm)
+
+    result = agent._call_with_retry(lambda: "ok")
+    assert result == "ok"
+
+
+def test_call_with_retry_returns_after_transient_failures() -> None:
+    """Succeeds on the third attempt after two transient failures."""
+    llm = MagicMock()
+    agent = ConcreteAgent(llm)
+
+    err = _make_retryable_error()
+    call_count = 0
+
+    def _flaky():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise err
+        return "recovered"
+
+    with patch("opendove.agents.base._RETRYABLE_EXCEPTIONS", (type(err),)), \
+         patch("opendove.agents.base.time.sleep"):
+        result = agent._call_with_retry(_flaky, label="test call")
+
+    assert result == "recovered"
+    assert call_count == 3
+
+
+def test_call_with_retry_raises_llm_call_error_after_max_retries() -> None:
+    """Exhausts all retries and raises LLMCallError."""
+    llm = MagicMock()
+    agent = ConcreteAgent(llm)
+
+    err = _make_retryable_error()
+
+    def _always_fail():
+        raise err
+
+    with patch("opendove.agents.base._RETRYABLE_EXCEPTIONS", (type(err),)), \
+         patch("opendove.agents.base.time.sleep"):
+        with pytest.raises(LLMCallError):
+            agent._call_with_retry(_always_fail, label="always fails")
+
+
+def test_call_with_retry_does_not_retry_non_transient_errors() -> None:
+    """Non-retryable errors propagate immediately without retrying."""
+    llm = MagicMock()
+    agent = ConcreteAgent(llm)
+
+    call_count = 0
+
+    def _value_error():
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("permanent error")
+
+    with patch("opendove.agents.base._RETRYABLE_EXCEPTIONS", ()):
+        with pytest.raises(ValueError, match="permanent error"):
+            agent._call_with_retry(_value_error)
+
+    assert call_count == 1
+
+
+def test_call_with_retry_attempt_count_matches_max_retries() -> None:
+    """The callable is invoked exactly _MAX_RETRIES times before giving up."""
+    llm = MagicMock()
+    agent = ConcreteAgent(llm)
+
+    err = _make_retryable_error()
+    call_count = 0
+
+    def _always_fail():
+        nonlocal call_count
+        call_count += 1
+        raise err
+
+    with patch("opendove.agents.base._RETRYABLE_EXCEPTIONS", (type(err),)), \
+         patch("opendove.agents.base.time.sleep"):
+        with pytest.raises(LLMCallError):
+            agent._call_with_retry(_always_fail)
+
+    assert call_count == _MAX_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Graph escalation on LLMCallError
+# ---------------------------------------------------------------------------
+
+
+def _make_task() -> Task:
+    return Task(
+        title="Retry Test",
+        intent="Test LLM retry escalation.",
+        success_criteria=["Task escalates on LLM failure."],
+        owner=Role.DEVELOPER,
+    )
+
+
+class _LLMFailProductManager(MagicMock):
+    """Fake agent whose run() raises LLMCallError."""
+    def run(self, state: GraphState) -> GraphState:
+        raise LLMCallError("LLM exhausted for product_manager_node")
+
+
+def test_graph_escalates_task_on_llm_call_error() -> None:
+    """When a node raises LLMCallError, the graph escalates the task and ends cleanly."""
+    graph = build_graph(product_manager_agent=_LLMFailProductManager())
+
+    initial: GraphState = {
+        "task": _make_task(),
+        "messages": [],
+        "retry_count": 0,
+        "architect_retry_count": 0,
+        "worktree_path": "",
+    }
+
+    result = graph.invoke(initial)
+    final_task: Task = result["task"]
+
+    assert final_task.status is TaskStatus.ESCALATED
+    assert final_task.validation_result is not None
+    assert final_task.validation_result.decision is ValidationDecision.ESCALATE
+    assert "LLM call failed" in final_task.validation_result.rationale
+    assert any("escalated" in msg for msg in result["messages"])


### PR DESCRIPTION
## Summary
- `BaseAgent._call_with_retry()` wraps any LLM callable with exponential backoff + jitter over transient errors (`RateLimitError`, `APITimeoutError`, `APIConnectionError` from both `anthropic` and `openai` SDKs)
- `_call_llm()` and `_call_llm_structured()` both route through `_call_with_retry` transparently
- `LLMCallError` is raised when all 3 retry attempts are exhausted
- Every graph node is wrapped with `_wrap_with_llm_error_guard`: a `LLMCallError` mid-pipeline sets `task.status = ESCALATED` and routes to `END` rather than crashing the process
- Non-transient errors (e.g. `ValueError`) propagate immediately without retrying

## Test plan
- [x] Succeeds on first attempt — no retry overhead
- [x] Recovers after 2 transient failures on attempt 3
- [x] Raises `LLMCallError` after exactly `_MAX_RETRIES` (3) attempts
- [x] Non-retryable errors propagate immediately (1 call, no sleep)
- [x] Attempt count equals `_MAX_RETRIES` exactly before giving up
- [x] Graph escalates task cleanly when a node raises `LLMCallError`
- [x] All 125 tests pass, 8 skipped

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)