### PR TITLE
feat: DeepSeek LLM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ OPENDOVE_ENV=local
 
 # ── LLM — global defaults ────────────────────────────────────────────────────
 
-# Default LLM provider for all agents. Options: anthropic | openai | gemini
+# Default LLM provider for all agents. Options: anthropic | openai | gemini | deepseek
 OPENDOVE_LLM_PROVIDER=anthropic
 
 # Default model for all agents.
@@ -31,10 +31,11 @@ OPENDOVE_LLM_MODEL=claude-sonnet-4-6
 OPENDOVE_ANTHROPIC_API_KEY=
 OPENDOVE_OPENAI_API_KEY=
 OPENDOVE_GEMINI_API_KEY=
+OPENDOVE_DEEPSEEK_API_KEY=
 
 # ── LLM — per-role overrides (optional) ─────────────────────────────────────
 # Leave blank to inherit the global default above.
-# Options per field: provider = anthropic | openai | gemini
+# Options per field: provider = anthropic | openai | gemini | deepseek
 
 OPENDOVE_PRODUCT_MANAGER_LLM_PROVIDER=
 OPENDOVE_PRODUCT_MANAGER_LLM_MODEL=

--- a/src/opendove/agents/llm_factory.py
+++ b/src/opendove/agents/llm_factory.py
@@ -18,6 +18,14 @@ def build_llm(provider: str, model: str, settings: Settings) -> BaseChatModel:
         from langchain_google_genai import ChatGoogleGenerativeAI
 
         return ChatGoogleGenerativeAI(model=model, google_api_key=settings.gemini_api_key or None)
+    if provider == "deepseek":
+        from langchain_openai import ChatOpenAI
+
+        return ChatOpenAI(
+            model=model,
+            api_key=settings.deepseek_api_key or None,
+            base_url="https://api.deepseek.com/v1",
+        )
     raise ValueError(f"Unsupported LLM provider: {provider!r}")
 
 

--- a/src/opendove/config.py
+++ b/src/opendove/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     workspace_dir: Path = Path.home() / ".opendove"
     database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5432/opendove"
 
-    llm_provider: Literal["anthropic", "openai", "gemini"] = "anthropic"
+    llm_provider: Literal["anthropic", "openai", "gemini", "deepseek"] = "anthropic"
     llm_model: str = "claude-sonnet-4-6"
 
     product_manager_llm_provider: str = ""
@@ -42,6 +42,7 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     openai_api_key: str = ""
     gemini_api_key: str = ""
+    deepseek_api_key: str = ""
     github_token: str = ""
     github_issue_label: str = "opendove"
     github_sync_interval_minutes: int = 5

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -66,3 +66,36 @@ def test_all_roles_resolve() -> None:
     for role in Role:
         result = build_llm_for_role(role, settings)
         assert isinstance(result, ChatAnthropic)
+
+
+def test_build_llm_deepseek() -> None:
+    """build_llm with provider=deepseek returns a ChatOpenAI instance pointing at DeepSeek."""
+    settings = Settings(
+        llm_provider="anthropic",
+        llm_model="claude-sonnet-4-6",
+        anthropic_api_key="test-key",
+        deepseek_api_key="ds-test-key",
+        _env_file=None,
+    )
+
+    result = build_llm("deepseek", "deepseek-chat", settings)
+
+    assert isinstance(result, ChatOpenAI)
+    assert "deepseek" in str(result.openai_api_base).lower()
+
+
+def test_build_llm_for_role_uses_deepseek_override() -> None:
+    """A role-level deepseek override resolves to ChatOpenAI."""
+    settings = Settings(
+        llm_provider="anthropic",
+        llm_model="claude-sonnet-4-6",
+        anthropic_api_key="test-key",
+        deepseek_api_key="ds-test-key",
+        developer_llm_provider="deepseek",
+        developer_llm_model="deepseek-coder",
+        _env_file=None,
+    )
+
+    result = build_llm_for_role(Role.DEVELOPER, settings)
+
+    assert isinstance(result, ChatOpenAI)


### PR DESCRIPTION
## Summary
- Adds `"deepseek"` as a valid `llm_provider` option alongside `anthropic`, `openai`, `gemini`
- `build_llm("deepseek", ...)` returns a `ChatOpenAI` instance with `base_url=https://api.deepseek.com/v1` (DeepSeek's OpenAI-compatible endpoint)
- New `OPENDOVE_DEEPSEEK_API_KEY` setting wired through `Settings` and `.env.example`
- Per-role overrides work identically — set `OPENDOVE_DEVELOPER_LLM_PROVIDER=deepseek` to route a single agent to DeepSeek

## Test plan
- [x] `test_build_llm_deepseek` — `build_llm("deepseek", ...)` returns `ChatOpenAI` with DeepSeek base URL
- [x] `test_build_llm_for_role_uses_deepseek_override` — role-level override resolves to `ChatOpenAI`
- [x] All 127 tests pass, 8 skipped

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)