### PR TITLE
feat: arm agents with file/bash tools (#48)

### DIFF
--- a/src/opendove/agents/developer.py
+++ b/src/opendove/agents/developer.py
@@ -4,6 +4,7 @@ import logging
 
 from opendove.agents.base import BaseAgent
 from opendove.agents.schemas import DeveloperOutput
+from opendove.agents.tools import BashTool, GlobTool, GrepTool, ReadFileTool, WriteFileTool
 from opendove.models.task import TaskStatus
 from opendove.orchestration.graph import GraphState
 
@@ -34,6 +35,14 @@ running tests. Use them. Always run the tests before declaring work complete.
 
 class DeveloperAgent(BaseAgent):
     DEFAULT_SYSTEM_PROMPT: str = _SYSTEM_PROMPT
+
+    def __init__(self, llm, system_prompt: str = _SYSTEM_PROMPT, **kwargs) -> None:
+        super().__init__(
+            llm=llm,
+            system_prompt=system_prompt,
+            tools=[ReadFileTool(), GlobTool(), GrepTool(), WriteFileTool(), BashTool()],
+            **kwargs,
+        )
 
     def run(self, state: GraphState) -> GraphState:
         task = state["task"]

--- a/src/opendove/agents/lead_architect.py
+++ b/src/opendove/agents/lead_architect.py
@@ -4,6 +4,7 @@ import logging
 
 from opendove.agents.base import BaseAgent
 from opendove.agents.schemas import ArchitectReviewOutput, LeadArchitectOutput
+from opendove.agents.tools import GlobTool, GrepTool, ReadFileTool
 from opendove.orchestration.graph import GraphState
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,14 @@ Rules:
 
 class LeadArchitectAgent(BaseAgent):
     DEFAULT_SYSTEM_PROMPT: str = _SYSTEM_PROMPT
+
+    def __init__(self, llm, system_prompt: str = _SYSTEM_PROMPT, **kwargs) -> None:
+        super().__init__(
+            llm=llm,
+            system_prompt=system_prompt,
+            tools=[ReadFileTool(), GlobTool(), GrepTool()],
+            **kwargs,
+        )
 
     def run(self, state: GraphState) -> GraphState:
         task = state["task"]

--- a/src/opendove/agents/tools.py
+++ b/src/opendove/agents/tools.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+from langchain_core.tools import BaseTool
+
+
+class ReadFileTool(BaseTool):
+    name: str = "read_file"
+    description: str = "Read the contents of a file. Input: absolute file path."
+
+    def _run(self, path: str) -> str:
+        try:
+            return Path(path).read_text()
+        except Exception as e:
+            return f"Error reading {path}: {e}"
+
+
+class GlobTool(BaseTool):
+    name: str = "glob"
+    description: str = "Find files matching a glob pattern. Input JSON: {\"pattern\": \"**/*.py\", \"cwd\": \"/path/to/dir\"}"
+
+    def _run(self, input: str) -> str:
+        import json
+        try:
+            data = json.loads(input)
+            cwd = Path(data.get("cwd", "."))
+            matches = list(cwd.glob(data["pattern"]))
+            return "\n".join(str(m) for m in matches) or "No matches found."
+        except Exception as e:
+            return f"Error: {e}"
+
+
+class GrepTool(BaseTool):
+    name: str = "grep"
+    description: str = "Search file contents using grep. Input JSON: {\"pattern\": \"regex\", \"cwd\": \"/path\"}"
+
+    def _run(self, input: str) -> str:
+        import json
+        try:
+            data = json.loads(input)
+            result = subprocess.run(
+                ["grep", "-r", "-n", "--include=*.py", data["pattern"], "."],
+                cwd=data.get("cwd", "."), capture_output=True, text=True
+            )
+            return result.stdout or "No matches."
+        except Exception as e:
+            return f"Error: {e}"
+
+
+class WriteFileTool(BaseTool):
+    name: str = "write_file"
+    description: str = "Write content to a file (creates parent dirs). Input JSON: {\"path\": \"/abs/path\", \"content\": \"...\"}"
+
+    def _run(self, input: str) -> str:
+        import json
+        try:
+            data = json.loads(input)
+            p = Path(data["path"])
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(data["content"])
+            return f"Written: {p}"
+        except Exception as e:
+            return f"Error: {e}"
+
+
+class BashTool(BaseTool):
+    name: str = "bash"
+    description: str = "Run a shell command. Input JSON: {\"command\": \"pytest tests/\", \"cwd\": \"/path/to/worktree\"}"
+
+    def _run(self, input: str) -> str:
+        import json
+        try:
+            data = json.loads(input)
+            result = subprocess.run(
+                data["command"], shell=True, cwd=data.get("cwd", "."),
+                capture_output=True, text=True, timeout=120
+            )
+            output = result.stdout + result.stderr
+            return output[:4000] or "(no output)"
+        except Exception as e:
+            return f"Error: {e}"


### PR DESCRIPTION
## Summary

- Add `src/opendove/agents/tools.py` with 5 LangChain `BaseTool` subclasses: `ReadFileTool`, `GlobTool`, `GrepTool`, `WriteFileTool`, `BashTool`
- Wire `LeadArchitectAgent` with `[ReadFileTool, GlobTool, GrepTool]` via a new `__init__`
- Wire `DeveloperAgent` with all 5 tools via a new `__init__`

Closes #48

## Test plan
- [ ] `uv run pytest tests/ -x -q` passes
- [ ] `LeadArchitectAgent` and `DeveloperAgent` instantiate with tools populated
- [ ] `BaseAgent._react_agent` is set when tools are provided

🤖 Generated with Claude Code