### PR TITLE
fix: authenticate git push and clone with GitHub token

### DIFF
--- a/src/opendove/git/manager.py
+++ b/src/opendove/git/manager.py
@@ -6,13 +6,15 @@ class GitManager:
     """Wraps git CLI operations for repo and worktree lifecycle."""
 
     @staticmethod
-    def clone(repo_url: str, target_path: Path) -> None:
+    def clone(repo_url: str, target_path: Path, github_token: str = "") -> None:
         """Clone repo_url into target_path. Raises RuntimeError on failure."""
         target_path.parent.mkdir(parents=True, exist_ok=True)
+        url = repo_url
+        if github_token and url.startswith("https://"):
+            url = url.replace("https://", f"https://x-access-token:{github_token}@")
         result = subprocess.run(
-            ["git", "clone", repo_url, str(target_path)],
-            capture_output=True,
-            text=True,
+            ["git", "clone", url, str(target_path)],
+            capture_output=True, text=True,
         )
         if result.returncode != 0:
             raise RuntimeError(f"git clone failed: {result.stderr.strip()}")
@@ -40,17 +42,39 @@ class GitManager:
         )
 
     @staticmethod
-    def commit_and_push(worktree_path: Path, message: str, remote: str = "origin") -> None:
+    def commit_and_push(worktree_path: Path, message: str, remote: str = "origin", github_token: str = "") -> None:
         """Stage all changes, commit, and push the current branch."""
         for cmd in [
             ["git", "-C", str(worktree_path), "add", "-A"],
             ["git", "-C", str(worktree_path), "commit", "--allow-empty", "-m", message],
-            ["git", "-C", str(worktree_path), "push", remote, "HEAD"],
         ]:
             result = subprocess.run(cmd, capture_output=True, text=True)
             if result.returncode != 0:
-                raise RuntimeError(
-                    f"git command failed: {' '.join(cmd)}\n{result.stderr.strip()}"
+                raise RuntimeError(f"git command failed: {' '.join(cmd)}\n{result.stderr.strip()}")
+
+        original_url = ""
+        if github_token:
+            url_result = subprocess.run(
+                ["git", "-C", str(worktree_path), "remote", "get-url", remote],
+                capture_output=True, text=True,
+            )
+            original_url = url_result.stdout.strip()
+            authed_url = original_url.replace("https://", f"https://x-access-token:{github_token}@")
+            subprocess.run(
+                ["git", "-C", str(worktree_path), "remote", "set-url", remote, authed_url], check=True
+            )
+
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(worktree_path), "push", remote, "HEAD"],
+                capture_output=True, text=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"git push failed: {result.stderr.strip()}")
+        finally:
+            if github_token and original_url:
+                subprocess.run(
+                    ["git", "-C", str(worktree_path), "remote", "set-url", remote, original_url]
                 )
 
     @staticmethod

--- a/src/opendove/orchestration/worker.py
+++ b/src/opendove/orchestration/worker.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from uuid import UUID
 
+from opendove.config import settings
 from opendove.git.manager import GitManager
 from opendove.models.task import TaskStatus
 from opendove.orchestration.task_runner import TaskRunner
@@ -76,7 +77,7 @@ class TaskWorker:
 
             if not repo_path.exists():
                 logger.info("Worker: cloning %s -> %s", project.repo_url, repo_path)
-                GitManager.clone(project.repo_url, repo_path)
+                GitManager.clone(project.repo_url, repo_path, github_token=settings.github_token or "")
 
             branch_name = f"feat/task-{task_id_str[:8]}"
             logger.info("Worker: creating worktree at %s (branch %s)", worktree_path, branch_name)
@@ -91,10 +92,8 @@ class TaskWorker:
 
             if result.status.value == "approved":
                 logger.info("Worker: committing and pushing worktree %s", worktree_path)
-                GitManager.commit_and_push(worktree_path, f"feat: {task.title}")
+                GitManager.commit_and_push(worktree_path, f"feat: {task.title}", github_token=settings.github_token or "")
                 try:
-                    from opendove.config import settings
-
                     pr_url = GitManager.create_pull_request(
                         repo_url=project.repo_url,
                         branch=branch_name,


### PR DESCRIPTION
Closes #54

## Summary
- `GitManager.clone()` now accepts `github_token` and embeds it in the HTTPS URL before cloning
- `GitManager.commit_and_push()` now accepts `github_token`, temporarily sets an authenticated remote URL for the push, and restores the original URL in a finally block
- `TaskWorker._run_task()` passes `settings.github_token` to both methods; top-level import of `settings` replaces the lazy import

## Test plan
- [ ] `uv run pytest tests/ -x -q` passes with no failures
- [ ] Clone of a private repo succeeds when `OPENDOVE_GITHUB_TOKEN` is set
- [ ] Push step uses the token-authenticated URL and restores the original URL after push

🤖 Generated with Claude Code
