### PR TITLE
docs: OpenDove workflow design and Phase 1 scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ build/
 *.egg-info/
 .DS_Store
 
+# OpenDove runtime files (session transcripts, architect briefs)
+# Design docs (WORKFLOW.md, PHASE*.md) are committed and excluded here
+.opendove/sessions/
+.opendove/briefs/
+

--- a/.opendove/PHASE1.md
+++ b/.opendove/PHASE1.md
@@ -1,0 +1,240 @@
+# Phase 1 — Contribution Mode Core Pipeline
+
+## Goal
+
+Deliver a working end-to-end contribution mode pipeline:
+PdM selects an issue → pipeline implements it → PR is created → poller tracks it → DB is updated.
+
+No PdM session interface, no autonomous mode, no milestone management, no email notifications.
+
+---
+
+## Out of Scope for Phase 1
+
+- Autonomous mode (PdM research, issue creation, user session)
+- GitHub sub-issues (contribution mode uses internal sub-tasks only)
+- PdM acceptance review (no PdM in contribution mode pipeline)
+- Email / Discord notifications
+- Dashboard
+- Daily token budget enforcement (tracked but not enforced)
+- Parallel task conflict detection
+
+---
+
+## Deliverables
+
+### 1. Project model — mode field
+
+**File:** `src/opendove/models/project.py`
+
+Add `mode: Literal["contribution", "autonomous"] = "contribution"` to the `Project` model.
+
+**API:** `POST /projects` body accepts `mode`. `GET /projects` and `GET /projects/{id}` return it.
+
+---
+
+### 2. Task status — full lifecycle
+
+**File:** `src/opendove/models/task.py`
+
+Replace current `TaskStatus` with:
+
+```python
+class TaskStatus(str, Enum):
+    PENDING = "pending"
+    QUEUED = "queued"
+    IN_PROGRESS = "in_progress"
+    PENDING_EXTERNAL_REVIEW = "pending_external_review"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    ESCALATED = "escalated"
+    CLOSED = "closed"
+```
+
+---
+
+### 3. Retry counters on Task model
+
+**File:** `src/opendove/models/task.py`
+
+Add independent retry counters:
+
+```python
+precheck_retry_count: int = 0
+architect_review_retry_count: int = 0
+external_review_retry_count: int = 0
+```
+
+These are independent of the existing `retry_count` (which tracks Developer retries).
+
+---
+
+### 4. Worktree lifecycle — keep alive while PR is open
+
+**File:** `src/opendove/orchestration/worker.py`
+
+Current behaviour: worktree is always removed in the `finally` block.
+
+New behaviour:
+- If task status is `PENDING_EXTERNAL_REVIEW` → do **not** remove the worktree
+- Worktree is removed only when the poller marks the task as `APPROVED`, `CLOSED`, or `ESCALATED`
+
+---
+
+### 5. PdM issue selection tool
+
+**File:** `src/opendove/agents/product_manager.py`
+
+New capability: given a repo URL, fetch open GitHub issues and select a subset to enqueue. For Phase 1 this is a simple tool call — PdM reads open issues and returns a list of issue numbers to enqueue.
+
+**Tool required:** GitHub API — `GET /repos/{owner}/{repo}/issues`
+
+PdM enqueues selected issues via the dispatcher.
+
+---
+
+### 6. Architect — full pipeline role
+
+**File:** `src/opendove/agents/lead_architect.py`
+
+Replace current stub behaviour with:
+
+1. **Assess issue**: read the issue body + codebase (Claude Code MCP), decide atomic vs compound
+2. **Produce technical brief**: always output a structured brief for Developer
+3. **Code review**: after Developer pushes, read the diff + test output, approve or reject with specific reason
+4. **Create PR**: on approval, call GitHub API to open PR with issue reference in body
+5. **Read PR review comments**: when re-activated after `PENDING_EXTERNAL_REVIEW`, read maintainer's comments and produce revised guidance for Developer
+
+**Tools required:**
+- Claude Code MCP (full codebase read)
+- GitHub API: read issue, read PR diff, read PR review comments, create PR
+
+---
+
+### 7. Developer — implement on branch
+
+**File:** `src/opendove/agents/developer.py`
+
+Current behaviour: Developer writes files using file tools (working).
+
+New behaviour additions:
+- Developer always pulls latest from the base branch before starting
+- Developer receives the Architect's technical brief as primary instruction
+- On re-activation after external review: Developer receives Architect's interpretation of maintainer comments as instruction, and continues on the same branch (worktree already exists)
+
+---
+
+### 8. Pre-checks gate
+
+**File:** `src/opendove/agents/ava_checks.py` (rename to `src/opendove/checks/pre_checks.py`)
+
+Automated checks run before Architect code review:
+- CI status: green on the pushed branch (GitHub API: `GET /repos/{owner}/{repo}/commits/{ref}/status`)
+- Files changed: at least one file modified in the worktree (existing `check_files_changed`)
+
+On failure:
+- Increment `precheck_retry_count`
+- If `precheck_retry_count < 2`: Architect diagnoses from test output + diff, produces fix guidance for Developer
+- If `precheck_retry_count >= 2`: task → `ESCALATED`
+
+---
+
+### 9. Graph redesign
+
+**File:** `src/opendove/orchestration/graph.py`
+
+Replace the current linear graph with the Phase 1 contribution mode graph:
+
+```
+START
+  ↓
+pjm_node          (prioritize, assign)
+  ↓
+architect_plan_node   (assess, brief)
+  ↓
+developer_node        (implement, test, push)
+  ↓
+pre_checks_node       (CI, files changed)
+  ↓ fail → architect_precheck_escalation_node → developer_node (max 2)
+  ↓ pass
+architect_review_node (code review)
+  ↓ reject → developer_node (max 2)
+  ↓ approve
+architect_create_pr_node  (open PR on GitHub)
+  ↓
+END  (task → PENDING_EXTERNAL_REVIEW)
+```
+
+---
+
+### 10. PR poller
+
+**File:** `src/opendove/scheduler/pr_poller.py`
+
+New scheduled job (every 5 minutes):
+
+1. Query DB for all tasks with status `PENDING_EXTERNAL_REVIEW`
+2. For each task, call GitHub API: `GET /repos/{owner}/{repo}/pulls/{pull_number}`
+3. On **merged**: set task → `APPROVED`, remove worktree, update DB
+4. On **closed without merge**: set task → `CLOSED`, remove worktree, update DB
+5. On **review requested changes**: set task → `QUEUED` (re-insert at original priority, top of tier), keep worktree
+
+Register this job in the scheduler alongside the existing worker tick.
+
+---
+
+### 11. PjM progress tracking
+
+**File:** `src/opendove/agents/project_manager.py`
+
+After each task reaches a terminal state (`APPROVED`, `CLOSED`, `ESCALATED`):
+- Update task record in DB with final status and timestamp
+- Comment on the GitHub issue with a brief status update (contribution mode: "PR merged by maintainer" / "PR closed" / "Escalated — needs human review")
+
+---
+
+### 12. API additions
+
+**File:** `src/opendove/api/routers/projects.py`
+
+- `POST /projects/{id}/select-issues` — PdM selects GitHub issues to enqueue (contribution mode)
+- `GET /projects/{id}/tasks` — add `precheck_retry_count`, `architect_review_retry_count`, `external_review_retry_count` to `TaskResponse`
+
+---
+
+## Implementation Order
+
+Issues should be implemented in this order to avoid blocking dependencies:
+
+```
+1.  Project.mode field + API
+2.  TaskStatus full lifecycle
+3.  Retry counters on Task
+4.  Pre-checks gate (rename + CI check)
+5.  Graph redesign (skeleton, stubs ok)
+6.  Architect — plan + code review + create PR
+7.  Developer — pull latest + re-activation on same branch
+8.  Worktree lifecycle fix (keep alive on PENDING_EXTERNAL_REVIEW)
+9.  PR poller
+10. PdM issue selection
+11. PjM progress tracking + GitHub comment
+12. API additions
+```
+
+---
+
+## Acceptance Criteria for Phase 1
+
+- [ ] Register a project in contribution mode via API
+- [ ] Call `POST /projects/{id}/select-issues` with a list of GitHub issue numbers → tasks enqueued
+- [ ] Worker picks up task → Architect reads issue + codebase → produces technical brief
+- [ ] Developer implements on branch in worktree → pushes
+- [ ] Pre-checks run → if CI fails, Architect diagnoses, Developer fixes (up to 2 rounds)
+- [ ] Architect reviews code → rejects with reason or approves
+- [ ] On approval → PR created on GitHub referencing the issue
+- [ ] Task status transitions to `PENDING_EXTERNAL_REVIEW`
+- [ ] Next queued task starts immediately
+- [ ] Poller detects PR merged → task → `APPROVED`, worktree removed
+- [ ] Poller detects changes requested → task re-queued → Architect reads comments → Developer fixes same PR
+- [ ] All task statuses visible via `GET /projects/{id}/tasks`
+- [ ] Full test suite passes

--- a/.opendove/WORKFLOW.md
+++ b/.opendove/WORKFLOW.md
@@ -1,0 +1,185 @@
+# OpenDove Workflow Design
+
+## Overview
+
+OpenDove is an autonomous software development system that contributes to GitHub repositories using a team of AI agents. It operates in two modes:
+
+- **Contribution Mode** — OpenDove works on issues from an existing repo, following the repo's contribution guidelines and creating PRs for maintainer review.
+- **Autonomous Mode** — OpenDove owns the product direction on a personal repo. The Product Manager agent drives feature creation, research, and delivery autonomously with periodic user check-ins.
+
+Both modes share the same core development pipeline. They differ only in how work enters the system and what happens after a PR is created.
+
+---
+
+## Roles
+
+| Agent | Responsibility |
+|---|---|
+| **Product Manager (PdM)** | Selects or creates issues, reviews completed work against product vision, reports to user, manages daily token budget |
+| **Project Manager (PjM)** | Prioritizes the work queue, assigns milestones, tracks progress in DB, manages re-queuing of blocked tasks |
+| **Architect** | Assesses issue complexity, produces technical brief, optionally decomposes into sub-tasks (autonomous mode only), reviews code quality and test results, creates PR on approval |
+| **Developer** | Implements sub-task or issue, runs tests, pushes branch |
+| **Pre-checks** | Automated gate (not an agent): CI passed, files changed. Blocks Architect review if failed |
+
+> **Note:** AVA (Alignment & Validation Agent) is retired as a standalone agent. Its automated checks become the pre-checks gate. Technical review is owned by the Architect. Product alignment is owned by PdM.
+
+---
+
+## Unified Pipeline
+
+```
+CONTRIBUTION MODE                      AUTONOMOUS MODE
+─────────────────                      ────────────────
+PdM selects open issues           ←→   PdM session with user
+from target repo                        PdM researches + creates issues
+(up to daily token budget)              (up to daily token budget)
+        ↓                                      ↓
+        └────────────── enqueue to project ────┘
+                             ↓
+        PjM prioritizes queue, assigns to milestone (both modes)
+                             ↓
+        Architect: read codebase, assess issue
+          → atomic (fits one PR)  → produce technical brief → Developer
+          → compound (autonomous only) → decompose into sub-tasks
+            → create sub-issues on GitHub via API
+            → produce technical brief per sub-task → Developer
+                             ↓
+        ┌── INNER LOOP (per sub-task or issue) ───────────────────────┐
+        │                                                              │
+        │  Developer: implement, test, push branch                    │
+        │  (worktree stays alive while PR is open)                    │
+        │       ↓                                                      │
+        │  Pre-checks: CI passed? files changed?                      │
+        │       ↓ fail → Architect diagnoses root cause               │
+        │               → guidance to Developer (max 2 escalations)  │
+        │               → after 2: escalate to human                  │
+        │  Architect: code review                                      │
+        │       ↓ reject → Developer fixes (max 2 rounds)            │
+        │       ↓ approve → create PR                                 │
+        │                                                              │
+        │  CONTRIBUTION MODE:                                         │
+        │    → status: PENDING_EXTERNAL_REVIEW                        │
+        │    → continue next task from queue                          │
+        │    [background poller watches PR]                           │
+        │      merged / closed → remove from queue, update DB         │
+        │      changes requested → re-queue at original priority      │
+        │          (top of same priority tier)                        │
+        │          → Architect reads PR review comments               │
+        │          → briefs Developer → fix in same PR (max 2 rounds) │
+        │                                                              │
+        │  AUTONOMOUS MODE:                                           │
+        │    PdM: review PR + parent issue + test output              │
+        │       ↓ reject / request changes (max 2 rounds)            │
+        │           → Architect guidance → Developer fixes same PR    │
+        │       ↓ accept → auto-merge                                 │
+        └──────────────────────────────────────────────────────────────┘
+                             ↓
+        PjM: all sub-tasks done for parent issue?
+          → no: next sub-task
+          → yes: proceed to outer loop
+                             ↓
+        ┌── OUTER LOOP (per parent issue) ────────────────────────────┐
+        │                                                              │
+        │  CONTRIBUTION MODE:                                         │
+        │    PjM: update issue status in DB                           │
+        │    (issue stays open on GitHub — maintainer closes it)      │
+        │                                                              │
+        │  AUTONOMOUS MODE:                                           │
+        │    PjM: close GitHub issue, update milestone progress in DB │
+        │    milestone complete?                                       │
+        │      → yes: PdM compiles report → email user → new session  │
+        │      → no: next issue from queue                            │
+        └──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Retry Limits (all independent counters)
+
+| Trigger | Max rounds | After limit |
+|---|---|---|
+| Pre-checks fail | 2 | Architect escalation |
+| Architect escalation (pre-checks) | 2 | Human escalation |
+| Architect code review reject | 2 | Human escalation |
+| Maintainer requests changes | 2 | Human escalation |
+| PdM rejects (autonomous) | 2 | Human escalation |
+
+---
+
+## Task Status Model
+
+```
+PENDING               → created, not yet queued
+QUEUED                → in the work queue
+IN_PROGRESS           → agent pipeline is actively running
+PENDING_EXTERNAL_REVIEW → PR created, waiting for maintainer
+APPROVED              → merged (autonomous) or accepted (contribution)
+REJECTED              → failed validation, being retried
+ESCALATED             → exceeded retry limit, needs human
+BLOCKED               → dependency not yet resolved
+CLOSED                → done, issue updated
+```
+
+---
+
+## State Persistence
+
+**GitHub is the source of truth** for issues, sub-issues, PRs, and milestones.
+
+**OpenDove DB** stores only:
+- Project registration: repo URL, mode, settings, daily token budget
+- Task execution state: current status, retry counters, which graph node
+- Links: `task → github_issue_number`, `task → github_pr_url`
+
+**Repo files** (`.opendove/` directory, gitignored) store:
+- Milestone definitions
+- PdM session transcripts and conclusions
+- Architect technical briefs
+
+---
+
+## Agent Tooling
+
+| Agent | Tools |
+|---|---|
+| PdM | GitHub API (read/create issues), web search, email |
+| PjM | GitHub API (read issues, update status), DB |
+| Architect | Claude Code MCP (full codebase access), GitHub API (create sub-issues, read PR reviews, create/merge PR) |
+| Developer | Read, write, edit files; Bash (run tests); Glob; Grep |
+| Pre-checks | CI status via GitHub API, git diff |
+
+---
+
+## GitHub Token Requirements
+
+A **Classic Personal Access Token** with `repo` scope is required for both modes.
+
+- Contribution mode: push branches, create PRs, read PR review comments
+- Autonomous mode: all of the above + merge PRs on owned repos
+
+Token is set as `OPENDOVE_GITHUB_TOKEN` in `.env`.
+
+---
+
+## Daily Token Budget
+
+- Per-project setting stored in DB
+- PdM tracks cumulative LLM API tokens consumed per day
+- When budget is reached, PdM stops selecting/creating new issues
+- In-flight tasks complete normally
+- Budget resets at midnight UTC
+
+---
+
+## Mode Comparison
+
+| Aspect | Contribution Mode | Autonomous Mode |
+|---|---|---|
+| Issue source | PdM selects from existing repo | PdM creates via research + user session |
+| Sub-issue decomposition | Internal sub-tasks only (not on GitHub) | GitHub sub-issues created by Architect |
+| PR per issue | One PR per issue (all sub-tasks on one branch) | One PR per sub-issue |
+| Post-PR | Maintainer reviews and merges | PdM reviews and auto-merges |
+| Issue closure | Maintainer closes; PjM updates DB | PjM closes GitHub issue |
+| PdM role | Minimal (queue entry + token budget) | Full (research, create, accept, report) |
+| Milestone management | PjM tracks in DB | PjM tracks in DB + GitHub milestones |
+| User notification | DB/dashboard (future) | Email on milestone completion |


### PR DESCRIPTION
Adds canonical design documentation under `.opendove/`:

- **WORKFLOW.md** — full dual-mode pipeline design (contribution + autonomous), role definitions, retry limits, state model, tooling, and persistence strategy
- **PHASE1.md** — scoped implementation plan for contribution mode: 12 deliverables, implementation order, and acceptance criteria

These docs are the reference for all Phase 1 implementation work.